### PR TITLE
fix: variable name conflict from merge mis-match

### DIFF
--- a/src/RoundwoodJoinery/Joint/Joint.cc
+++ b/src/RoundwoodJoinery/Joint/Joint.cc
@@ -77,7 +77,7 @@ namespace RoundwoodJoinery::Joinery
     double RoundwoodJoinery::Joinery::JointFace::ComputeCurrentArea(RoundwoodJoinery::PointCloud::PointCloud& pointCloud, double alpha)
     {
 
-        this->_projectedPoints = this->ProjectPointsOntoFace(beamPointCloud);
+        this->_projectedPoints = this->ProjectPointsOntoFace(pointCloud);
 
         if (this->_projectedPoints.size() < 3)
         {


### PR DESCRIPTION
variable name mis-match